### PR TITLE
Fix of conflicting internalized substrates computation

### DIFF
--- a/reactions-diffusion/biofvm/kernels/cpu_solver/src/cell_solver.cpp
+++ b/reactions-diffusion/biofvm/kernels/cpu_solver/src/cell_solver.cpp
@@ -116,18 +116,22 @@ void ballot_and_sum(const auto ballot_l, std::atomic<real_t>* HWY_RESTRICT reduc
 
 template <typename density_layout_t>
 void compute_internalized(real_t* HWY_RESTRICT internalized_substrates, const real_t* HWY_RESTRICT substrate_densities,
-						  const real_t* HWY_RESTRICT numerator, const real_t* HWY_RESTRICT denominator,
-						  const real_t* HWY_RESTRICT factor, real_t voxel_volume, density_layout_t dens_l)
+						  const real_t* HWY_RESTRICT secretion_rates, const real_t* HWY_RESTRICT uptake_rates,
+						  const real_t* HWY_RESTRICT saturation_densities, const real_t* HWY_RESTRICT net_export_rate,
+						  real_t agent_volume, real_t voxel_volume, real_t timestep, density_layout_t dens_l)
 {
 	const index_t substrates_count = dens_l | noarr::get_length<'s'>();
 
 	for (index_t s = 0; s < substrates_count; s++)
 	{
-		internalized_substrates[s] -=
-			voxel_volume
-			* (((-denominator[s]) * (dens_l | noarr::get_at<'s'>(substrate_densities, s)) + numerator[s])
-				   / (1 + denominator[s])
-			   + factor[s]);
+		const real_t D = (dens_l | noarr::get_at<'s'>(substrate_densities, s));
+		const real_t S = secretion_rates[s];
+		const real_t T = saturation_densities[s];
+		const real_t U = uptake_rates[s];
+		const real_t N = net_export_rate[s];
+
+		internalized_substrates[s] -= timestep * agent_volume * (S * (T - D) - U * D)
+									  + timestep * N * (1 + timestep * (agent_volume / voxel_volume) * (S + U));
 	}
 }
 
@@ -160,25 +164,27 @@ void compute_fused(real_t* HWY_RESTRICT substrate_densities, real_t* HWY_RESTRIC
 
 	for (index_t s = 0; s < substrates_count; s++)
 	{
-		internalized_substrates[s] -= voxel_volume
-									  * (((1 - denominator[s].load(std::memory_order_relaxed))
-											  * (dens_l | noarr::get_at<'s'>(substrate_densities, s))
-										  + numerator[s].load(std::memory_order_relaxed))
-											 / (denominator[s].load(std::memory_order_relaxed))
-										 + factor[s].load(std::memory_order_relaxed));
+		auto tmp = (dens_l | noarr::get_at<'s'>(substrate_densities, s));
+		// internalized_substrates[s] -= voxel_volume
+		// 							  * (((1 - denominator[s].load(std::memory_order_relaxed))
+		// 									  * (dens_l | noarr::get_at<'s'>(substrate_densities, s))
+		// 								  + numerator[s].load(std::memory_order_relaxed))
+		// 									 / (denominator[s].load(std::memory_order_relaxed))
+		// 								 + factor[s].load(std::memory_order_relaxed));
 
 		(dens_l | noarr::get_at<'s'>(substrate_densities, s)) =
 			((dens_l | noarr::get_at<'s'>(substrate_densities, s)) + numerator[s].load(std::memory_order_relaxed))
 				/ denominator[s].load(std::memory_order_relaxed)
 			+ factor[s].load(std::memory_order_relaxed);
+
+		internalized_substrates[s] += voxel_volume * (tmp - (dens_l | noarr::get_at<'s'>(substrate_densities, s)));
 	}
 }
 
 template <index_t dims>
 void compute_result(const auto dens_l, const auto ballot_l, agent_data& data, const cartesian_mesh& mesh,
-					real_t* substrates, const std::atomic<real_t>* reduced_numerators,
+					const real_t timestep, real_t* substrates, const std::atomic<real_t>* reduced_numerators,
 					const std::atomic<real_t>* reduced_denominators, const std::atomic<real_t>* reduced_factors,
-					const real_t* numerators, const real_t* denominators, const real_t* factors,
 					const std::atomic<index_t>* ballots, bool with_internalized, bool is_conflict)
 {
 	auto voxel_volume = (real_t)mesh.voxel_volume(); // expecting that voxel volume is the same for all voxels
@@ -199,19 +205,6 @@ void compute_result(const auto dens_l, const auto ballot_l, agent_data& data, co
 		return;
 	}
 
-	if (with_internalized)
-	{
-#pragma omp for
-		for (index_t i = 0; i < data.base_data.agents_count; i++)
-		{
-			auto fixed_dims = fix_dims<dims>(data.base_data.positions.data() + i * dims, mesh);
-
-			compute_internalized(data.internalized_substrates.data() + i * data.substrate_count, substrates,
-								 numerators + i * data.substrate_count, denominators + i * data.substrate_count,
-								 factors + i * data.substrate_count, voxel_volume, dens_l ^ fixed_dims);
-		}
-	}
-
 #pragma omp for
 	for (index_t i = 0; i < data.base_data.agents_count; i++)
 	{
@@ -221,6 +214,22 @@ void compute_result(const auto dens_l, const auto ballot_l, agent_data& data, co
 		compute_densities(substrates, reduced_numerators + i * data.substrate_count,
 						  reduced_denominators + i * data.substrate_count, reduced_factors + i * data.substrate_count,
 						  ballot == i, dens_l ^ fixed_dims);
+	}
+
+	if (with_internalized)
+	{
+#pragma omp for
+		for (index_t i = 0; i < data.base_data.agents_count; i++)
+		{
+			auto fixed_dims = fix_dims<dims>(data.base_data.positions.data() + i * dims, mesh);
+
+			compute_internalized(data.internalized_substrates.data() + i * data.substrate_count, substrates,
+								 data.secretion_rates.data() + i * data.substrate_count,
+								 data.uptake_rates.data() + i * data.substrate_count,
+								 data.saturation_densities.data() + i * data.substrate_count,
+								 data.net_export_rates.data() + i * data.substrate_count, data.volumes[i], voxel_volume,
+								 timestep, dens_l ^ fixed_dims);
+		}
 	}
 }
 
@@ -247,8 +256,8 @@ void simulate(const auto dens_l, const auto ballot_l, agent_data& data, microenv
 							 data.base_data.agents_count, data.substrate_count, m.mesh, is_conflict);
 	}
 
-	compute_result<dims>(dens_l, ballot_l, data, m.mesh, substrates, reduced_numerators, reduced_denominators,
-						 reduced_factors, numerators, denominators, factors, ballots, with_internalized,
+	compute_result<dims>(dens_l, ballot_l, data, m.mesh, m.diffusion_timestep, substrates, reduced_numerators,
+						 reduced_denominators, reduced_factors, ballots, with_internalized,
 						 is_conflict[0].load(std::memory_order_relaxed));
 }
 

--- a/reactions-diffusion/biofvm/kernels/cpu_solver/tests/test_cell_solver.cpp
+++ b/reactions-diffusion/biofvm/kernels/cpu_solver/tests/test_cell_solver.cpp
@@ -206,11 +206,14 @@ TEST_P(RecomputeTest, Simple1D)
 	EXPECT_FLOAT_EQ((densities.at<'x', 's'>(2, 0)), 475.398378);
 	EXPECT_FLOAT_EQ((densities.at<'x', 's'>(2, 1)), 1);
 
+	s.release_internalized_substrates(*m, d_s, 0);
+
 	if (compute_internalized)
 	{
-		s.release_internalized_substrates(*m, d_s, 0);
 		EXPECT_FLOAT_EQ((densities.at<'x', 's'>(0, 0)), 1);
 		EXPECT_FLOAT_EQ((densities.at<'x', 's'>(0, 1)), 1);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], 0);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], 0);
 	}
 }
 
@@ -289,11 +292,14 @@ TEST_P(RecomputeTest, Simple2D)
 	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(2, 2, 0)), 475.398378);
 	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(2, 2, 1)), 1);
 
+	s.release_internalized_substrates(*m, d_s, 0);
+
 	if (compute_internalized)
 	{
-		s.release_internalized_substrates(*m, d_s, 0);
 		EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(0, 0, 0)), 1);
 		EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(0, 0, 1)), 1);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], 0);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], 0);
 	}
 }
 
@@ -372,11 +378,14 @@ TEST_P(RecomputeTest, Simple3D)
 	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(2, 2, 2, 0)), 475.398378);
 	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(2, 2, 2, 1)), 1);
 
+	s.release_internalized_substrates(*m, d_s, 0);
+
 	if (compute_internalized)
 	{
-		s.release_internalized_substrates(*m, d_s, 0);
 		EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(0, 0, 0, 0)), 1);
 		EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(0, 0, 0, 1)), 1);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], 0);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], 0);
 	}
 }
 
@@ -465,6 +474,21 @@ TEST_P(RecomputeTest, Conflict)
 		{
 			EXPECT_FLOAT_EQ((densities.at<'x', 's'>(x, 0)), expected[2 * x]);
 			EXPECT_FLOAT_EQ((densities.at<'x', 's'>(x, 1)), expected[2 * x + 1]);
+		}
+	}
+
+#pragma omp parallel for
+	for (std::size_t i = 0; i < agents.size(); i++)
+	{
+		s.release_internalized_substrates(*m, d_s, i);
+	}
+
+	if (compute_internalized)
+	{
+		for (index_t x = 0; x < m->mesh.grid_shape[0]; x++)
+		{
+			EXPECT_FLOAT_EQ((densities.at<'x', 's'>(x, 0)), 1);
+			EXPECT_FLOAT_EQ((densities.at<'x', 's'>(x, 1)), 1);
 		}
 	}
 }

--- a/reactions-diffusion/biofvm/kernels/cpu_solver/tests/test_cell_solver.cpp
+++ b/reactions-diffusion/biofvm/kernels/cpu_solver/tests/test_cell_solver.cpp
@@ -60,8 +60,7 @@ static void compute_expected_agent_internalized_1d(auto densities, microenvironm
 				m.mesh.voxel_position(std::span<const real_t>(agent_data.base_data.positions.data() + i, 1));
 
 			expected_internalized[i * m.substrates_count + s] -=
-				(m.mesh.voxel_volume() * -denom * densities.template at<'x', 's'>(mesh_idx[0], s) + num) / (1 + denom)
-				+ factor;
+				(m.mesh.voxel_volume() * -denom * densities.template at<'x', 's'>(mesh_idx[0], s) + num) + factor;
 		}
 	}
 }
@@ -113,11 +112,11 @@ void set_default_agent_values(agent* a, index_t rates_offset, index_t volume, st
 	a->saturation_densities()[0] = rates_offset + 300;
 	a->saturation_densities()[1] = 0;
 
-	a->net_export_rates()[0] = rates_offset + 400;
-	a->net_export_rates()[1] = 0;
+	a->net_export_rates()[0] = 0;
+	a->net_export_rates()[1] = rates_offset + 400;
 
 	a->fraction_released_at_death()[0] = 1;
-	a->fraction_released_at_death()[1] = 0;
+	a->fraction_released_at_death()[1] = 1;
 
 	a->volume() = volume;
 
@@ -163,48 +162,48 @@ TEST_P(RecomputeTest, Simple1D)
 
 	if (compute_internalized)
 	{
-		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], -216004.000000);
-		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], -216000.000000);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], -4);
 
-		EXPECT_FLOAT_EQ(a2->internalized_substrates()[0], -1469060.631579);
-		EXPECT_FLOAT_EQ(a2->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a2->internalized_substrates()[0], -1469052.6);
+		EXPECT_FLOAT_EQ(a2->internalized_substrates()[1], -8);
 
-		EXPECT_FLOAT_EQ(a3->internalized_substrates()[0], -2927715.703704);
-		EXPECT_FLOAT_EQ(a3->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a3->internalized_substrates()[0], -2927703.8);
+		EXPECT_FLOAT_EQ(a3->internalized_substrates()[1], -12);
 	}
 
-	EXPECT_FLOAT_EQ((densities.template at<'x', 's'>(0, 0)), 28.000500);
-	EXPECT_FLOAT_EQ((densities.template at<'x', 's'>(0, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.template at<'x', 's'>(0, 0)), 28);
+	EXPECT_FLOAT_EQ((densities.template at<'x', 's'>(0, 1)), 1.0005);
 
-	EXPECT_FLOAT_EQ((densities.template at<'x', 's'>(1, 0)), 184.632579);
-	EXPECT_FLOAT_EQ((densities.template at<'x', 's'>(1, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.template at<'x', 's'>(1, 0)), 184.63158);
+	EXPECT_FLOAT_EQ((densities.template at<'x', 's'>(1, 1)), 1.001);
 
-	EXPECT_FLOAT_EQ((densities.template at<'x', 's'>(2, 0)), 366.964463);
-	EXPECT_FLOAT_EQ((densities.template at<'x', 's'>(2, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.template at<'x', 's'>(2, 0)), 366.963);
+	EXPECT_FLOAT_EQ((densities.template at<'x', 's'>(2, 1)), 1.0015);
 
 #pragma omp parallel
 	s.simulate_secretion_and_uptake(*m, d_s, recompute);
 
 	if (compute_internalized)
 	{
-		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], -216004.000000 + -157093.818182);
-		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], -373091);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], -8);
 
-		EXPECT_FLOAT_EQ(a2->internalized_substrates()[0], -1469060.631579 + -618551.844632);
-		EXPECT_FLOAT_EQ(a2->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a2->internalized_substrates()[0], -2087601.1);
+		EXPECT_FLOAT_EQ(a2->internalized_substrates()[1], -16);
 
-		EXPECT_FLOAT_EQ(a3->internalized_substrates()[0], -2927715.703704 + -867471.319407);
-		EXPECT_FLOAT_EQ(a3->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a3->internalized_substrates()[0], -3795171.5);
+		EXPECT_FLOAT_EQ(a3->internalized_substrates()[1], -24);
 	}
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 's'>(0, 0)), 47.637227);
-	EXPECT_FLOAT_EQ((densities.at<'x', 's'>(0, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 's'>(0, 0)), 47.636364);
+	EXPECT_FLOAT_EQ((densities.at<'x', 's'>(0, 1)), 1.001);
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 's'>(1, 0)), 261.951560);
-	EXPECT_FLOAT_EQ((densities.at<'x', 's'>(1, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 's'>(1, 0)), 261.95);
+	EXPECT_FLOAT_EQ((densities.at<'x', 's'>(1, 1)), 1.002);
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 's'>(2, 0)), 475.398378);
-	EXPECT_FLOAT_EQ((densities.at<'x', 's'>(2, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 's'>(2, 0)), 475.39642);
+	EXPECT_FLOAT_EQ((densities.at<'x', 's'>(2, 1)), 1.003);
 
 	s.release_internalized_substrates(*m, d_s, 0);
 
@@ -249,48 +248,48 @@ TEST_P(RecomputeTest, Simple2D)
 
 	if (compute_internalized)
 	{
-		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], -216004.000000);
-		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], -216000.000000);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], -4);
 
-		EXPECT_FLOAT_EQ(a2->internalized_substrates()[0], -1469060.631579);
-		EXPECT_FLOAT_EQ(a2->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a2->internalized_substrates()[0], -1469052.6);
+		EXPECT_FLOAT_EQ(a2->internalized_substrates()[1], -8);
 
-		EXPECT_FLOAT_EQ(a3->internalized_substrates()[0], -2927715.703704);
-		EXPECT_FLOAT_EQ(a3->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a3->internalized_substrates()[0], -2927703.8);
+		EXPECT_FLOAT_EQ(a3->internalized_substrates()[1], -12);
 	}
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(0, 0, 0)), 28.000500);
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(0, 0, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(0, 0, 0)), 28);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(0, 0, 1)), 1.0005);
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(1, 1, 0)), 184.632579);
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(1, 1, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(1, 1, 0)), 184.63158);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(1, 1, 1)), 1.001);
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(2, 2, 0)), 366.964463);
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(2, 2, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(2, 2, 0)), 366.963);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(2, 2, 1)), 1.0015);
 
 #pragma omp parallel
 	s.simulate_secretion_and_uptake(*m, d_s, recompute);
 
 	if (compute_internalized)
 	{
-		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], -216004.000000 + -157093.818182);
-		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], -373091);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], -8);
 
-		EXPECT_FLOAT_EQ(a2->internalized_substrates()[0], -1469060.631579 + -618551.844632);
-		EXPECT_FLOAT_EQ(a2->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a2->internalized_substrates()[0], -2087601.1);
+		EXPECT_FLOAT_EQ(a2->internalized_substrates()[1], -16);
 
-		EXPECT_FLOAT_EQ(a3->internalized_substrates()[0], -2927715.703704 + -867471.319407);
-		EXPECT_FLOAT_EQ(a3->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a3->internalized_substrates()[0], -3795171.5);
+		EXPECT_FLOAT_EQ(a3->internalized_substrates()[1], -24);
 	}
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(0, 0, 0)), 47.637227);
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(0, 0, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(0, 0, 0)), 47.636364);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(0, 0, 1)), 1.001);
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(1, 1, 0)), 261.951560);
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(1, 1, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(1, 1, 0)), 261.95);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(1, 1, 1)), 1.002);
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(2, 2, 0)), 475.398378);
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(2, 2, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(2, 2, 0)), 475.39642);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 's'>(2, 2, 1)), 1.003);
 
 	s.release_internalized_substrates(*m, d_s, 0);
 
@@ -335,48 +334,48 @@ TEST_P(RecomputeTest, Simple3D)
 
 	if (compute_internalized)
 	{
-		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], -216004.000000);
-		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], -216000.000000);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], -4);
 
-		EXPECT_FLOAT_EQ(a2->internalized_substrates()[0], -1469060.631579);
-		EXPECT_FLOAT_EQ(a2->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a2->internalized_substrates()[0], -1469052.6);
+		EXPECT_FLOAT_EQ(a2->internalized_substrates()[1], -8);
 
-		EXPECT_FLOAT_EQ(a3->internalized_substrates()[0], -2927715.703704);
-		EXPECT_FLOAT_EQ(a3->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a3->internalized_substrates()[0], -2927703.8);
+		EXPECT_FLOAT_EQ(a3->internalized_substrates()[1], -12);
 	}
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(0, 0, 0, 0)), 28.000500);
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(0, 0, 0, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(0, 0, 0, 0)), 28);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(0, 0, 0, 1)), 1.0005);
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(1, 1, 1, 0)), 184.632579);
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(1, 1, 1, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(1, 1, 1, 0)), 184.63158);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(1, 1, 1, 1)), 1.001);
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(2, 2, 2, 0)), 366.964463);
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(2, 2, 2, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(2, 2, 2, 0)), 366.963);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(2, 2, 2, 1)), 1.0015);
 
 #pragma omp parallel
 	s.simulate_secretion_and_uptake(*m, d_s, recompute);
 
 	if (compute_internalized)
 	{
-		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], -216004.000000 + -157093.818182);
-		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[0], -373091);
+		EXPECT_FLOAT_EQ(a1->internalized_substrates()[1], -8);
 
-		EXPECT_FLOAT_EQ(a2->internalized_substrates()[0], -1469060.631579 + -618551.844632);
-		EXPECT_FLOAT_EQ(a2->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a2->internalized_substrates()[0], -2087601.1);
+		EXPECT_FLOAT_EQ(a2->internalized_substrates()[1], -16);
 
-		EXPECT_FLOAT_EQ(a3->internalized_substrates()[0], -2927715.703704 + -867471.319407);
-		EXPECT_FLOAT_EQ(a3->internalized_substrates()[1], 0);
+		EXPECT_FLOAT_EQ(a3->internalized_substrates()[0], -3795171.5);
+		EXPECT_FLOAT_EQ(a3->internalized_substrates()[1], -24);
 	}
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(0, 0, 0, 0)), 47.637227);
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(0, 0, 0, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(0, 0, 0, 0)), 47.636364);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(0, 0, 0, 1)), 1.001);
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(1, 1, 1, 0)), 261.951560);
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(1, 1, 1, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(1, 1, 1, 0)), 261.95);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(1, 1, 1, 1)), 1.002);
 
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(2, 2, 2, 0)), 475.398378);
-	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(2, 2, 2, 1)), 1);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(2, 2, 2, 0)), 475.39642);
+	EXPECT_FLOAT_EQ((densities.at<'x', 'y', 'z', 's'>(2, 2, 2, 1)), 1.003);
 
 	s.release_internalized_substrates(*m, d_s, 0);
 
@@ -429,10 +428,10 @@ TEST_P(RecomputeTest, Conflict)
 
 	std::vector<real_t> expected_internalized(agent_data.base_data.agents_count * m->substrates_count, 0);
 
-	compute_expected_agent_internalized_1d(densities, *m, agent_data, expected_internalized);
-
 #pragma omp parallel
 	s.simulate_secretion_and_uptake(*m, d_s, true);
+
+	compute_expected_agent_internalized_1d(densities, *m, agent_data, expected_internalized);
 
 	if (compute_internalized)
 	{
@@ -453,10 +452,10 @@ TEST_P(RecomputeTest, Conflict)
 		}
 	}
 
-	compute_expected_agent_internalized_1d(densities, *m, agent_data, expected_internalized);
-
 #pragma omp parallel
 	s.simulate_secretion_and_uptake(*m, d_s, recompute);
+
+	compute_expected_agent_internalized_1d(densities, *m, agent_data, expected_internalized);
 
 	if (compute_internalized)
 	{
@@ -528,10 +527,10 @@ TEST_P(RecomputeTest, ConflictBig)
 
 	std::vector<real_t> expected_internalized(agent_data.base_data.agents_count * m->substrates_count, 0);
 
-	compute_expected_agent_internalized_1d(densities, *m, agent_data, expected_internalized);
-
 #pragma omp parallel
 	s.simulate_secretion_and_uptake(*m, d_s, true);
+
+	compute_expected_agent_internalized_1d(densities, *m, agent_data, expected_internalized);
 
 	if (compute_internalized)
 	{
@@ -552,10 +551,10 @@ TEST_P(RecomputeTest, ConflictBig)
 		}
 	}
 
-	compute_expected_agent_internalized_1d(densities, *m, agent_data, expected_internalized);
-
 #pragma omp parallel
 	s.simulate_secretion_and_uptake(*m, d_s, recompute);
+
+	compute_expected_agent_internalized_1d(densities, *m, agent_data, expected_internalized);
 
 	if (compute_internalized)
 	{

--- a/reactions-diffusion/biofvm/kernels/cpu_solver/tests/test_cell_solver.cpp
+++ b/reactions-diffusion/biofvm/kernels/cpu_solver/tests/test_cell_solver.cpp
@@ -574,4 +574,19 @@ TEST_P(RecomputeTest, ConflictBig)
 			EXPECT_FLOAT_EQ((densities.at<'x', 's'>(x, 1)), expected[2 * x + 1]);
 		}
 	}
+
+#pragma omp parallel for
+	for (std::size_t i = 0; i < agents.size(); i++)
+	{
+		s.release_internalized_substrates(*m, d_s, i);
+	}
+
+	if (compute_internalized)
+	{
+		for (index_t x = 0; x < m->mesh.grid_shape[0]; x++)
+		{
+			EXPECT_FLOAT_EQ((densities.at<'x', 's'>(x, 0)), 1);
+			EXPECT_FLOAT_EQ((densities.at<'x', 's'>(x, 1)), 1);
+		}
+	}
 }


### PR DESCRIPTION
Before, when multiple cells were in the same voxel, they internalized more substrate than they actually uptook/released.
This PR fixes this issue.