### PR TITLE
Update cccl to version with fixed device_delete

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -65,7 +65,6 @@
             },
             "environment": {
                 "TSAN_OPTIONS": "suppressions=${sourceDir}/tsan.supp",
-                "ASAN_OPTIONS": "suppressions=${sourceDir}/asan.supp",
                 "LSAN_OPTIONS": "suppressions=${sourceDir}/lsan.supp"
             }
         },

--- a/asan.supp
+++ b/asan.supp
@@ -1,2 +1,0 @@
-# Suppress until Thrust fixes device_delete
-alloc_dealloc_mismatch:physicore::biofvm::kernels::thrust_solver::bulk_solver::~bulk_solver()

--- a/ports-overlays/cccl/portfile.cmake
+++ b/ports-overlays/cccl/portfile.cmake
@@ -1,12 +1,12 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH URL https://github.com/NVIDIA/cccl.git REF
-  8c04b6539859932f5602e86d38314e4d87f96420)
+  c859e948453f41076cf9727958cc709799c21ffb)
 
 vcpkg_cmake_configure(
   SOURCE_PATH
   ${SOURCE_PATH}
   OPTIONS
-  -DCMAKE_CUDA_ARCHITECTURES=all-major-cccl
+  -DCMAKE_CUDA_ARCHITECTURES=all-major
   -DCCCL_ENABLE_UNSTABLE=OFF
   -DCCCL_ENABLE_LIBCUDACXX=OFF
   -DCCCL_ENABLE_CUB=OFF
@@ -44,5 +44,6 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libcudacxx PACKAGE_NAME
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/cub/detail/ptx-json")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports-overlays/cccl/vcpkg.json
+++ b/ports-overlays/cccl/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "cccl",
-    "version-string": "3.0.3",
+    "version-string": "3.1.0",
     "description": "CUDA Core Compute Libraries",
     "dependencies": [
         "vcpkg-cmake",

--- a/reactions-diffusion/biofvm/kernels/thrust_solver/src/bulk_solver.cpp
+++ b/reactions-diffusion/biofvm/kernels/thrust_solver/src/bulk_solver.cpp
@@ -51,15 +51,8 @@ void bulk_solver::solve(const microenvironment& m, diffusion_solver& d_solver)
 					 d_solver.get_substrates_layout());
 }
 
-#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-__global__ void delete_functor(device_bulk_functor* ptr) { delete ptr; }
-#endif
-
 bulk_solver::~bulk_solver()
 {
-#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-	delete_functor<<<1, 1>>>(func.get());
-#else
-	delete func.get();
-#endif
+	if (func)
+		thrust::device_delete(func);
 }

--- a/reactions-diffusion/biofvm/kernels/thrust_solver/src/cell_solver.cpp
+++ b/reactions-diffusion/biofvm/kernels/thrust_solver/src/cell_solver.cpp
@@ -490,6 +490,9 @@ void cell_solver::initialize(const microenvironment& m)
 
 cell_solver::~cell_solver()
 {
+	if (!is_conflict_)
+		return;
+
 	thrust::device_delete(is_conflict_);
 	thrust::device_delete(ballots_);
 }

--- a/reactions-diffusion/biofvm/kernels/thrust_solver/src/diffusion_solver.cpp
+++ b/reactions-diffusion/biofvm/kernels/thrust_solver/src/diffusion_solver.cpp
@@ -259,20 +259,32 @@ void diffusion_solver::solve()
 
 void diffusion_solver::deinitialize()
 {
-	thrust::device_delete(bx_);
-	thrust::device_delete(cx_);
-	thrust::device_delete(ex_);
+	if (bx_)
+	{
+		thrust::device_delete(bx_);
+		thrust::device_delete(cx_);
+		thrust::device_delete(ex_);
+	}
 
-	thrust::device_delete(by_);
-	thrust::device_delete(cy_);
-	thrust::device_delete(ey_);
+	if (by_)
+	{
+		thrust::device_delete(by_);
+		thrust::device_delete(cy_);
+		thrust::device_delete(ey_);
+	}
 
-	thrust::device_delete(bz_);
-	thrust::device_delete(cz_);
-	thrust::device_delete(ez_);
+	if (bz_)
+	{
+		thrust::device_delete(bz_);
+		thrust::device_delete(cz_);
+		thrust::device_delete(ez_);
+	}
 
-	thrust::device_delete(substrate_densities_);
-	thrust::device_delete(initial_conditions_);
+	if (substrate_densities_)
+	{
+		thrust::device_delete(substrate_densities_);
+		thrust::device_delete(initial_conditions_);
+	}
 }
 
 diffusion_solver::~diffusion_solver() { deinitialize(); }

--- a/reactions-diffusion/biofvm/tests/test_vtk_serializer.cpp
+++ b/reactions-diffusion/biofvm/tests/test_vtk_serializer.cpp
@@ -150,7 +150,6 @@ TEST_F(VtkSerializerTest, PvdFileContainsCorrectEntries)
 	EXPECT_TRUE(content.find("</VTKFile>") != std::string::npos);
 
 	// Check timestep entries
-	std::cout << content << std::endl;
 	EXPECT_TRUE(content.find("timestep=\"0.1") != std::string::npos);
 	EXPECT_TRUE(content.find("timestep=\"0.2") != std::string::npos);
 


### PR DESCRIPTION
Now, we can remove the hacky device delete in thrust bulk_solver.