### PR TITLE
Serialization improvements

### DIFF
--- a/reactions-diffusion/biofvm/examples/diffuse.cpp
+++ b/reactions-diffusion/biofvm/examples/diffuse.cpp
@@ -7,7 +7,6 @@
 #include <random>
 #include <vector>
 
-#include "config_reader.h"
 #include "microenvironment.h"
 
 using namespace physicore;
@@ -104,7 +103,8 @@ int main()
 	std::chrono::duration<double> diffusion_runtime { 0.0 };
 	std::chrono::duration<double> serialize_runtime { 0.0 };
 
-	// m->serialize_state();
+	m->solver->initialize(*m);
+	m->serialize_state(current_time);
 
 	std::cout << "\n[diffuse] Running simulation for " << m->simulation_time << " time units..." << std::endl;
 

--- a/reactions-diffusion/biofvm/include/solver.h
+++ b/reactions-diffusion/biofvm/include/solver.h
@@ -11,8 +11,13 @@ class microenvironment;
 class solver
 {
 public:
+	// Set initial values (such as substrate densities) in the microenvironment
+	virtual void initialize(microenvironment& m) = 0;
+
+	// Solve the diffusion-decay equations for a given number of iterations
 	virtual void solve(microenvironment& m, index_t iterations) = 0;
 
+	// Get the substrate density at a given voxel
 	virtual real_t get_substrate_density(index_t s, index_t x, index_t y, index_t z) const = 0;
 
 	virtual ~solver() = default;

--- a/reactions-diffusion/biofvm/kernels/openmp_solver/include/openmp_solver.h
+++ b/reactions-diffusion/biofvm/kernels/openmp_solver/include/openmp_solver.h
@@ -18,6 +18,7 @@ class openmp_solver : public solver
 	[[no_unique_address]] dirichlet_solver dir_solver;
 
 public:
+	void initialize(microenvironment& m) override;
 	void solve(microenvironment& m, index_t iterations) override;
 	real_t get_substrate_density(index_t s, index_t x, index_t y, index_t z) const override;
 };

--- a/reactions-diffusion/biofvm/kernels/openmp_solver/src/openmp_solver.cpp
+++ b/reactions-diffusion/biofvm/kernels/openmp_solver/src/openmp_solver.cpp
@@ -3,19 +3,24 @@
 using namespace physicore;
 using namespace physicore::biofvm::kernels::openmp_solver;
 
+void openmp_solver::initialize(biofvm::microenvironment& m)
+{
+	if (initialized)
+		return;
+
+	d_solver.prepare(m, 1);
+	d_solver.initialize();
+
+	b_solver.initialize(m);
+
+	c_solver.initialize(m);
+
+	initialized = true;
+}
+
 void openmp_solver::solve(biofvm::microenvironment& m, index_t iterations)
 {
-	if (!initialized)
-	{
-		d_solver.prepare(m, 1);
-		d_solver.initialize();
-
-		b_solver.initialize(m);
-
-		c_solver.initialize(m);
-
-		initialized = true;
-	}
+	initialize(m);
 
 #pragma omp parallel
 	for (index_t it = 0; it < iterations; it++)

--- a/reactions-diffusion/biofvm/kernels/thrust_solver/include/thrust_solver.h
+++ b/reactions-diffusion/biofvm/kernels/thrust_solver/include/thrust_solver.h
@@ -21,6 +21,7 @@ class thrust_solver : public solver
 	data_manager mgr;
 
 public:
+	void initialize(microenvironment& m) override;
 	void solve(microenvironment& m, index_t iterations) override;
 	real_t get_substrate_density(index_t s, index_t x, index_t y, index_t z) const override;
 };

--- a/reactions-diffusion/biofvm/kernels/thrust_solver/src/thrust_solver.cpp
+++ b/reactions-diffusion/biofvm/kernels/thrust_solver/src/thrust_solver.cpp
@@ -3,20 +3,25 @@
 using namespace physicore;
 using namespace physicore::biofvm::kernels::thrust_solver;
 
+void thrust_solver::initialize(biofvm::microenvironment& m)
+{
+	if (initialized)
+		return;
+
+	d_solver.initialize(m, 1);
+
+	dir_solver.initialize(m);
+
+	c_solver.initialize(m);
+
+	mgr.initialize(m, d_solver);
+
+	initialized = true;
+}
+
 void thrust_solver::solve(biofvm::microenvironment& m, index_t iterations)
 {
-	if (!initialized)
-	{
-		d_solver.initialize(m, 1);
-
-		dir_solver.initialize(m);
-
-		c_solver.initialize(m);
-
-		mgr.initialize(m, d_solver);
-
-		initialized = true;
-	}
+	initialize(m);
 
 	for (index_t it = 0; it < iterations; it++)
 	{

--- a/reactions-diffusion/biofvm/tests/test_solver_registry.cpp
+++ b/reactions-diffusion/biofvm/tests/test_solver_registry.cpp
@@ -9,6 +9,7 @@ using namespace physicore::biofvm;
 class mock_solver : public solver
 {
 public:
+	void initialize(microenvironment&) override {}
 	void solve(microenvironment&, index_t) override {}
 	real_t get_substrate_density(index_t, index_t, index_t, index_t) const override { return 0; }
 };

--- a/reactions-diffusion/biofvm/tests/test_vtk_serializer.cpp
+++ b/reactions-diffusion/biofvm/tests/test_vtk_serializer.cpp
@@ -244,7 +244,7 @@ TEST_F(VtkSerializerTest, SingleSubstrate)
 	);
 
 	auto m = builder.build();
-	m->solver->solve(*m, 1); // Initialize densities
+	m->solver->initialize(*m); // Initialize densities
 
 	vtk_serializer serializer(test_output_dir.string(), *m);
 
@@ -291,7 +291,7 @@ TEST_F(VtkSerializerTest, ManySubstrates)
 	}
 
 	auto m = builder.build();
-	m->solver->solve(*m, 1); // Initialize densities
+	m->solver->initialize(*m); // Initialize densities
 
 	vtk_serializer serializer(test_output_dir.string(), *m);
 
@@ -332,7 +332,7 @@ TEST_F(VtkSerializerTest, NonZeroBoundingBoxMins)
 	);
 
 	auto m = builder.build();
-	m->solver->solve(*m, 1); // Initialize densities
+	m->solver->initialize(*m); // Initialize densities
 
 	vtk_serializer serializer(test_output_dir.string(), *m);
 


### PR DESCRIPTION
This pull request introduces a new `initialize` method to the `solver` interface and its implementations, separating the initialization logic from the main `solve` routine for diffusion solvers. This change improves code clarity and ensures that solver initialization is explicit and consistent across different solver types. Associated test code and example usage have also been updated to use the new `initialize` method.

Further, we can now serialize the "initial state" without needing to call solve(...), which creates and immediately modified the initial state.