### PR TITLE
fix: ensure hwy dependency is present during install target

### DIFF
--- a/reactions-diffusion/biofvm/cmake/BioFVMConfig.cmake.in
+++ b/reactions-diffusion/biofvm/cmake/BioFVMConfig.cmake.in
@@ -11,6 +11,7 @@ if(NOT @BUILD_SHARED_LIBS@)
 
   # OpenMP solver dependencies
   find_dependency(OpenMP 4)
+  find_dependency(hwy)
 
   # Thrust solver dependencies (conditionally built)
   if(@BIOFVM_HAS_THRUST@)

--- a/reactions-diffusion/biofvm/kernels/openmp_solver/CMakeLists.txt
+++ b/reactions-diffusion/biofvm/kernels/openmp_solver/CMakeLists.txt
@@ -18,8 +18,7 @@ target_sources(
 
 target_link_libraries(
   reactions-diffusion.biofvm.kernels.openmp_solver_internal_iface
-  INTERFACE $<BUILD_INTERFACE:reactions-diffusion.biofvm_iface> common
-            $<BUILD_INTERFACE:hwy::hwy>)
+  INTERFACE $<BUILD_INTERFACE:reactions-diffusion.biofvm_iface> common hwy::hwy)
 
 find_path(NOARR_STRUCTURES_INCLUDE_DIRS "noarr/introspection.hpp")
 target_include_directories(


### PR DESCRIPTION
find_dependency(hwy) was missing from the BioFVMConfig.cmake.in file, which caused build failures when trying to use the statically built BioFVM.

Fixes #93