### PR TITLE
ci: use run-clang-tidy in the formal checks workflow

### DIFF
--- a/.github/workflows/formal-checks.yml
+++ b/.github/workflows/formal-checks.yml
@@ -30,6 +30,7 @@ jobs:
           sudo ./llvm.sh 20 all
           sudo ln -sf /usr/lib/llvm-20/bin/clang-format /usr/bin/clang-format
           sudo ln -sf /usr/lib/llvm-20/bin/clang-tidy /usr/bin/clang-tidy
+          sudo ln -sf /usr/lib/llvm-20/bin/run-clang-tidy /usr/bin/run-clang-tidy
 
       - name: Show versions
         run: |
@@ -64,7 +65,21 @@ jobs:
         with:
           os: ubuntu-latest
 
-      - name: Run clang-tidy analysis
+      - name: Configure project for clang-tidy
         uses: lukka/run-cmake@v10
         with:
-          workflowPreset: "llvm-tidy-debug"
+          configurePreset: "llvm-debug"
+
+      - name: Run clang-tidy analysis
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Running clang-tidy analysis..."
+          if ! run-clang-tidy -p build/llvm-debug; then
+            echo "clang-tidy found issues. Please fix them. Run:"
+            echo "  run-clang-tidy -p build -fix"
+            exit 1
+          fi
+
+          echo "clang-tidy analysis completed with no issues."

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -168,19 +168,6 @@
             ]
         },
         {
-            "name": "llvm-tidy-debug",
-            "displayName": "LLVM Clang-Tidy Build",
-            "inherits": [
-                "_root-config",
-                "_debug-base"
-            ],
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_CXX_CLANG_TIDY": "clang-tidy"
-            }
-        },
-        {
             "name": "llvm-cov-debug",
             "displayName": "LLVM Coverage Build",
             "inherits": [
@@ -359,13 +346,6 @@
         {
             "name": "llvm-cov-debug",
             "configurePreset": "llvm-cov-debug",
-            "inherits": [
-                "_root-build"
-            ]
-        },
-        {
-            "name": "llvm-tidy-debug",
-            "configurePreset": "llvm-tidy-debug",
             "inherits": [
                 "_root-build"
             ]
@@ -643,20 +623,6 @@
                 {
                     "type": "test",
                     "name": "llvm-debug"
-                }
-            ]
-        },
-        {
-            "name": "llvm-tidy-debug",
-            "displayName": "LLVM Clang-Tidy Build",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "llvm-tidy-debug"
-                },
-                {
-                    "type": "build",
-                    "name": "llvm-tidy-debug"
                 }
             ]
         },


### PR DESCRIPTION
This should speed up the formal checks workflow significantly by avoiding the need to do a full build with clang-tidy enabled. Instead, we use the run-clang-tidy script to directly analyze the source files.

Fixes #84