### PR TITLE
docs: add generic_agent_container documentation

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@ Checks: >
 
   cppcoreguidelines-*,
   -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-pro-bounds-constant-array-index,

--- a/common/tests/test_base_agent_container.cpp
+++ b/common/tests/test_base_agent_container.cpp
@@ -192,13 +192,13 @@ TEST(BaseAgentContainerTest, Instantiation)
 
 		// Data can be accessed
 		{
-			// physicore::generic_agent_solver<diffusion_agent> diff_accessor;
-			// diffusion_agent_data& d_accessed = diff_accessor.retrieve_agent_data(container);
-			// (void)d_accessed;
+			physicore::generic_agent_solver<diffusion_agent> diff_accessor;
+			diffusion_agent_data& d_accessed = diff_accessor.retrieve_agent_data(container);
+			(void)d_accessed;
 
-			// physicore::generic_agent_solver<mechanics_agent> mech_accessor;
-			// mechanics_agent_data& m_accessed = mech_accessor.retrieve_agent_data(container);
-			// (void)m_accessed;
+			physicore::generic_agent_solver<mechanics_agent> mech_accessor;
+			mechanics_agent_data& m_accessed = mech_accessor.retrieve_agent_data(container);
+			(void)m_accessed;
 		}
 
 		mechanics_container.create();

--- a/common/tests/test_base_agent_container.cpp
+++ b/common/tests/test_base_agent_container.cpp
@@ -156,15 +156,15 @@ public:
 
 TEST(BaseAgentContainerTest, Instantiation)
 {
-	generic_agent_and_data_container<base_agent> base_container(std::make_unique<base_agent_data>());
+	const generic_agent_and_data_container<base_agent> base_container(std::make_unique<base_agent_data>());
 
 	// Instantiate diffusion container
 	{
 		auto base_data = std::make_unique<physicore::base_agent_data>();
 		auto diffusion_data = std::make_unique<diffusion_agent_data>(*base_data);
 
-		generic_agent_and_data_container<base_agent, diffusion_agent> container(std::move(base_data),
-																				std::move(diffusion_data));
+		const generic_agent_and_data_container<base_agent, diffusion_agent> container(std::move(base_data),
+																					  std::move(diffusion_data));
 	}
 
 	// Instantiate mechanics container
@@ -172,8 +172,8 @@ TEST(BaseAgentContainerTest, Instantiation)
 		auto base_data = std::make_unique<physicore::base_agent_data>();
 		auto mechanics_data = std::make_unique<mechanics_agent_data>(*base_data);
 
-		generic_agent_and_data_container<base_agent, mechanics_agent> container(std::move(base_data),
-																				std::move(mechanics_data));
+		const generic_agent_and_data_container<base_agent, mechanics_agent> container(std::move(base_data),
+																					  std::move(mechanics_data));
 	}
 
 	// Instantiate big (union of diffusion and mechanics) container
@@ -193,11 +193,11 @@ TEST(BaseAgentContainerTest, Instantiation)
 		// Data can be accessed
 		{
 			physicore::generic_agent_solver<diffusion_agent> diff_accessor;
-			diffusion_agent_data& d_accessed = diff_accessor.retrieve_agent_data(container);
+			const diffusion_agent_data& d_accessed = diff_accessor.retrieve_agent_data(container);
 			(void)d_accessed;
 
 			physicore::generic_agent_solver<mechanics_agent> mech_accessor;
-			mechanics_agent_data& m_accessed = mech_accessor.retrieve_agent_data(container);
+			const mechanics_agent_data& m_accessed = mech_accessor.retrieve_agent_data(container);
 			(void)m_accessed;
 		}
 

--- a/common/tests/test_base_agent_container.cpp
+++ b/common/tests/test_base_agent_container.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
 #include "base_agent_container.h"
+#include "base_agent_data.h"
+#include "generic_agent_solver.h"
 
 using namespace physicore;
 
@@ -58,3 +60,153 @@ TEST_P(RemoveAgentTest, RemoveAgentsAndCheckPositions)
 }
 
 INSTANTIATE_TEST_SUITE_P(BaseAgentContainerTest, RemoveAgentTest, ::testing::Values(0, 1, 2));
+
+class diffusion_agent_data
+{
+public:
+	base_agent_data& data;
+
+	void add() {}
+
+	void remove_at(index_t /* position */) {}
+
+	diffusion_agent_data(base_agent_data& data) : data(data) {}
+};
+
+class diffusion_agent_interface : public virtual base_agent_interface
+{};
+
+class diffusion_agent : public base_agent, public virtual diffusion_agent_interface
+{
+	diffusion_agent_data& data;
+
+public:
+	using DataType = diffusion_agent_data;
+	using InterfaceType = diffusion_agent_interface;
+
+	diffusion_agent(index_t index,
+					std::tuple<std::unique_ptr<base_agent_data>, std::unique_ptr<diffusion_agent_data>>& datas)
+		: base_agent_interface(index), base_agent(index, *std::get<0>(datas)), data(*std::get<1>(datas))
+	{}
+};
+
+class mechanics_agent_data
+{
+public:
+	base_agent_data& data;
+
+	void add() {}
+
+	void remove_at(index_t /* position */) {}
+
+	mechanics_agent_data(base_agent_data& data) : data(data) {}
+};
+
+class mechanics_agent_interface : public virtual base_agent_interface
+{};
+
+class mechanics_agent : public base_agent, public virtual mechanics_agent_interface
+{
+	mechanics_agent_data& data;
+
+public:
+	using DataType = mechanics_agent_data;
+	using InterfaceType = mechanics_agent_interface;
+
+	mechanics_agent(index_t index,
+					std::tuple<std::unique_ptr<base_agent_data>, std::unique_ptr<mechanics_agent_data>>& datas)
+		: base_agent_interface(index), base_agent(index, *std::get<0>(datas)), data(*std::get<1>(datas))
+	{}
+};
+
+class big_agent_data
+{
+public:
+	base_agent_data& data1;
+	diffusion_agent_data& data2;
+	mechanics_agent_data& data3;
+
+	void add() {}
+
+	void remove_at(index_t /* position */) {}
+
+	big_agent_data(base_agent_data& data1, diffusion_agent_data& data2, mechanics_agent_data& data3)
+		: data1(data1), data2(data2), data3(data3)
+	{}
+};
+
+class big_agent_interface : public virtual base_agent_interface,
+							public virtual diffusion_agent_interface,
+							public virtual mechanics_agent_interface
+{};
+
+class big_agent : public base_agent, public virtual big_agent_interface
+{
+public:
+	big_agent_data& data;
+
+	using DataType = big_agent_data;
+	using InterfaceType = big_agent_interface;
+
+	big_agent(index_t index, std::tuple<std::unique_ptr<base_agent_data>, std::unique_ptr<diffusion_agent_data>,
+										std::unique_ptr<mechanics_agent_data>, std::unique_ptr<big_agent_data>>& datas)
+		: base_agent_interface(index), base_agent(index, *std::get<0>(datas)), data(*std::get<3>(datas))
+	{}
+};
+
+TEST(BaseAgentContainerTest, Instantiation)
+{
+	generic_agent_and_data_container<base_agent> base_container(std::make_unique<base_agent_data>());
+
+	// Instantiate diffusion container
+	{
+		auto base_data = std::make_unique<physicore::base_agent_data>();
+		auto diffusion_data = std::make_unique<diffusion_agent_data>(*base_data);
+
+		generic_agent_and_data_container<base_agent, diffusion_agent> container(std::move(base_data),
+																				std::move(diffusion_data));
+	}
+
+	// Instantiate mechanics container
+	{
+		auto base_data = std::make_unique<physicore::base_agent_data>();
+		auto mechanics_data = std::make_unique<mechanics_agent_data>(*base_data);
+
+		generic_agent_and_data_container<base_agent, mechanics_agent> container(std::move(base_data),
+																				std::move(mechanics_data));
+	}
+
+	// Instantiate big (union of diffusion and mechanics) container
+	{
+		auto base_data = std::make_unique<physicore::base_agent_data>();
+		auto diffusion_data = std::make_unique<diffusion_agent_data>(*base_data);
+		auto mechanics_data = std::make_unique<mechanics_agent_data>(*base_data);
+		auto big_data = std::make_unique<big_agent_data>(*base_data, *diffusion_data, *mechanics_data);
+
+		generic_agent_and_data_container<base_agent, diffusion_agent, mechanics_agent, big_agent> container(
+			std::move(base_data), std::move(diffusion_data), std::move(mechanics_data), std::move(big_data));
+
+		// Can be down-casted
+		generic_agent_interface_container<diffusion_agent_interface>& diffusion_container = container;
+		generic_agent_interface_container<mechanics_agent_interface>& mechanics_container = container;
+
+		// Data can be accessed
+		{
+			// physicore::generic_agent_solver<diffusion_agent> diff_accessor;
+			// diffusion_agent_data& d_accessed = diff_accessor.retrieve_agent_data(container);
+			// (void)d_accessed;
+
+			// physicore::generic_agent_solver<mechanics_agent> mech_accessor;
+			// mechanics_agent_data& m_accessed = mech_accessor.retrieve_agent_data(container);
+			// (void)m_accessed;
+		}
+
+		mechanics_container.create();
+		ASSERT_EQ(diffusion_container.size(), 1);
+		ASSERT_EQ(mechanics_container.size(), 1);
+
+		diffusion_container.create();
+		ASSERT_EQ(diffusion_container.size(), 2);
+		ASSERT_EQ(mechanics_container.size(), 2);
+	}
+}

--- a/docs/Common.md
+++ b/docs/Common.md
@@ -169,55 +169,219 @@ classDiagram
 ```
 
 
-<!-- ## Agent Containers
+## Agent Containers
 
-The `base_agent_container` provides high-level management of agent collections:
+The agent container system manages collections of agents, owns their SoA data, and provides type-safe access. The implementation is built entirely from templates in `common/include/common/generic_agent_container.h`.
 
-```cpp
-namespace physicore::common {
+### Template Hierarchy
 
-class base_agent_container {
-public:
-    // Add a new agent
-    base_agent create_agent(real_t x, real_t y, real_t z);
+Three layers form a clean separation of concerns:
 
-    // Access agent by index
-    base_agent operator[](std::size_t index);
+```mermaid
+classDiagram
+    class generic_agent_interface_container~AgentType~ {
+        <<abstract>>
+        +create() AgentType*
+        +get_agent_at(index_t) AgentType*
+        +remove_agent(base_agent_interface*)
+        +remove_at(index_t)
+        +size() size_t
+        #get_agent_index(base_agent_interface*) index_t&
+    }
 
-    // Iterate over all agents
-    auto begin();
-    auto end();
+    class generic_agent_impl_container~AgentType~ {
+        #data : AgentType__DataType&
+    }
 
-    // Get number of agents
-    std::size_t size() const;
+    class generic_agent_and_data_container~AgentTypes...~ {
+        +agent_datas : tuple
+        #agents : vector
+        +create() MostConcreteAgentType*
+        +get_agent_at(index_t) MostConcreteAgentType*
+        +remove_at(index_t)
+        +size() size_t
+    }
 
-    // Remove agent
-    void remove(std::size_t index);
-
-private:
-    base_agent_data data_;
-};
-
-} // namespace physicore::common
+    generic_agent_interface_container <|-- generic_agent_impl_container
+    generic_agent_impl_container <|-- generic_agent_and_data_container
 ```
 
-**Usage Example:**
+**Layer 1 — `generic_agent_interface_container<AgentType>`**
+
+The abstract interface any container exposes. Constrained by the `derived_from_base_agent` concept, requiring `AgentType` to inherit from `base_agent_interface`. This is the contract that solvers and other consumers depend on — they never see the concrete container type.
+
+**Layer 2 — `generic_agent_impl_container<AgentType>`**
+
+Holds a typed, non-owning reference (`AgentType::DataType&`) to the underlying SoA data. This layer is the injection point: the reference is provided in the constructor and lets `generic_agent_solver` extract the data from a polymorphic container at runtime.
+
+**Layer 3 — `generic_agent_and_data_container<AgentTypes...>`**
+
+The concrete, data-owning container. It is variadic — it accepts any number of agent types and owns one `std::unique_ptr<DataType>` for each in a `std::tuple`. The last type in the parameter pack is the **most-concrete agent type** (the type actually instantiated for each agent object). It inherits from `generic_agent_impl_container<T>` for every `T` in the pack, making it queryable as any of those interface types.
+
+### Lifecycle Operations
+
+**Creating an agent** (`create()`):
+
+```cpp
+MostConcreteAgentType* create() override
+{
+    // 1. Grow every data array by one element
+    (std::get<std::unique_ptr<typename AgentTypes::DataType>>(agent_datas)->add(), ...);
+    // 2. Construct a proxy whose index == current size (before push)
+    auto new_agent = std::make_unique<MostConcreteAgentType>(this->size(), agent_datas);
+    agents.emplace_back(std::move(new_agent));
+    return agents.back().get();
+}
+```
+
+`create()` is the only way to obtain a valid agent pointer. The returned raw pointer is owned by the container — callers must not `delete` it.
+
+**Removing an agent** (`remove_at(index_t position)`):
+
+Removal runs in O(1) using a **swap-with-last** strategy:
+
+1. Call `remove_at(position)` on every data array (also swap-with-last inside each SoA)
+2. Fix up the index of the last agent's proxy (now moved to `position`)
+3. Swap `agents[position]` with `agents.back()`
+4. Pop the last element
+
+This avoids any memory shifting. It invalidates the index of the agent that was previously at the last position (its index is now `position`), but all proxy references remain valid because the heap-allocated proxy object itself was not moved.
+
+### `base_agent_container` — the Simplest Case
+
+For contexts that only need to track positions (e.g., unit tests or a pure geometry pass):
+
+```cpp
+// common/include/common/base_agent_container.h
+using base_agent_container = generic_agent_and_data_container<base_agent>;
+```
 
 ```cpp
 #include <common/base_agent_container.h>
 
-base_agent_container container;
+physicore::base_agent_container container(
+    std::make_unique<physicore::base_agent_data>(3 /*dims*/));
 
-// Create agents
-auto agent1 = container.create_agent(0.0, 0.0, 0.0);
-auto agent2 = container.create_agent(1.0, 1.0, 1.0);
+physicore::base_agent* a1 = container.create();
+physicore::base_agent* a2 = container.create();
 
-// Iterate and modify
-for (auto agent : container) {
-    real_t x = agent.position_x();
-    agent.set_velocity_x(x * 0.1);
+a1->position()[0] = 10.0;  // set x of agent 1
+
+container.remove_agent(a1);  // O(1), a2 is now at index 0
+```
+
+---
+
+### Sharing Base Agent Data Across Containers
+
+A central design goal of PhysiCore is that **positions (and other common agent attributes) are stored exactly once**, yet are accessible to every physics module (diffusion, mechanics, phenotype). The key idea is:
+
+- There is **one** `generic_agent_and_data_container` that owns all data.
+- Each domain-specific data structure (`biofvm::agent_data`, `mechanics::agent_data`, …) holds a **non-owning reference** to `base_agent_data` — there is never a copy of positions.
+- Because the container inherits from `generic_agent_impl_container<T>` for every type in its pack, it can be **implicitly cast** to any module's `container_interface` type and used independently by each module.
+
+```mermaid
+graph LR
+    subgraph container["generic_agent_and_data_container"]
+        direction TB
+        bd["base_agent_data(positions[])"]
+        dd["biofvm::agent_data(secretion_rates[], …)"]
+        md["mechanics::agent_data(velocities[], radii[], …)"]
+        dd -- "base_data&" --> bd
+        md -- "base_data&" --> bd
+    end
+
+    container -- "cast to biofvm::agent_container_interface&" --> BioFVM
+    container -- "cast to mechanics::agent_container_interface&" --> Mechanics
+
+    BioFVM["BioFVM solver(reads secretion_rates, volumes, …)"]
+    Mechanics["Mechanics solver(reads velocities, radii, …)"]
+```
+
+#### How the Reference Stays Valid
+
+`generic_agent_and_data_container` owns every data object as a `unique_ptr` in a `std::tuple`. Domain data is constructed **before** ownership is transferred, so the reference each domain data struct holds into `base_agent_data` is already pointing at the final, stable heap address:
+
+```cpp
+// Constructing biofvm::agent_container (pack: base_agent, biofvm::agent)
+auto base_data = std::make_unique<physicore::base_agent_data>(3 /*dims*/);
+auto diff_data = std::make_unique<physicore::biofvm::agent_data>(*base_data, 5 /*substrates*/);
+//   ^^^^^^^^^ diff_data.base_data now points at *base_data on the heap
+
+physicore::biofvm::agent_container container(std::move(base_data), std::move(diff_data));
+// container owns both unique_ptrs; diff_data.base_data reference remains valid forever
+```
+
+The same pattern applies for every additional domain added to the pack. `biofvm::agent_container` is the existing real-world example:
+
+```cpp
+// reactions-diffusion/biofvm/include/biofvm/agent_container.h
+using agent_container           = physicore::generic_agent_and_data_container<base_agent, agent>;
+using agent_container_interface = physicore::generic_agent_interface_container<agent_interface>;
+using container_ptr             = std::shared_ptr<agent_container_interface>;
+```
+
+| Position in pack | `AgentType` | `DataType` | Owns data? |
+|---|---|---|---|
+| 0 | `base_agent` | `base_agent_data` | Yes — positions |
+| 1 | `biofvm::agent` | `biofvm::agent_data` | Yes — holds `base_data&` |
+
+#### Extending to a Second Domain (Conceptual)
+
+Adding a second domain follows the same pattern: define an `agent_data` struct with a `base_agent_data&` reference, a concrete `agent` type (last in the pack), and widen the `generic_agent_and_data_container` parameter pack. The resulting container can be implicitly cast to the `container_interface` of any domain in the pack and used independently by each module's solver.
+
+A self-contained working example of this — with a `diffusion_agent`, a `mechanics_agent`, and a combined `big_agent` that satisfies both interfaces — is in [`common/tests/test_base_agent_container.cpp`](https://github.com/bsc-life/PhysiCore/blob/main/common/tests/test_base_agent_container.cpp) (test `BaseAgentContainerTest.Instantiation`). The key parts of that test:
+
+```cpp
+// One container owns all four data objects
+generic_agent_and_data_container<base_agent, diffusion_agent, mechanics_agent, big_agent> container(
+    std::move(base_data), std::move(diffusion_data), std::move(mechanics_data), std::move(big_data));
+
+// Implicitly cast to either module's interface — no extra container needed
+generic_agent_interface_container<diffusion_agent_interface>& diffusion_view = container;
+generic_agent_interface_container<mechanics_agent_interface>& mechanics_view  = container;
+
+// Both views stay in sync: create() through one is visible through the other
+mechanics_view.create();
+ASSERT_EQ(diffusion_view.size(), 1);  // true
+
+diffusion_view.create();
+ASSERT_EQ(mechanics_view.size(), 2);  // true
+```
+
+---
+
+## `generic_agent_solver` — Typed Data Extraction
+
+Solvers receive containers through polymorphic `container_ptr` (or a `container_interface&`) references. They need the concrete, typed `DataType&` to perform computations. `generic_agent_solver` bridges this gap safely:
+
+```cpp
+// common/include/common/generic_agent_solver.h
+template <derived_from_base_agent AgentType>
+class generic_agent_solver
+{
+public:
+    typename AgentType::DataType& retrieve_agent_data(
+        generic_agent_interface_container<typename AgentType::InterfaceType>& container)
+    {
+        auto& casted = dynamic_cast<generic_agent_impl_container<AgentType>&>(container);
+        return casted.data;
+    }
+};
+```
+
+**Usage inside a solver:**
+
+```cpp
+// Inside a BioFVM solver that holds a container_ptr
+void biofvm_solver::run_single_timestep() {
+    physicore::generic_agent_solver<physicore::biofvm::agent> accessor;
+    physicore::biofvm::agent_data& data = accessor.retrieve_agent_data(*container_);
+    // data.secretion_rates, data.volumes, etc. are now directly accessible
 }
-``` -->
+```
+
+The `dynamic_cast` is safe because any object implementing `generic_agent_interface_container<agent_interface>` is always constructed as a `generic_agent_and_data_container<base_agent, agent>`, which inherits from `generic_agent_impl_container<biofvm::agent>` — the type relationship is established at construction time.
 
 ## Core Types
 


### PR DESCRIPTION
Common docs page now contains container documentation. Also added test that showcases the future usage.

Fixes #89